### PR TITLE
Fix sending plain text metadata instead of JSON string

### DIFF
--- a/Sources/SceytChatUIKit/Resources/en.lproj/Localizable.strings
+++ b/Sources/SceytChatUIKit/Resources/en.lproj/Localizable.strings
@@ -187,7 +187,7 @@
 "message.attachment.voice" = "Voice";
 "message.forward.title" = "Forwarded message";
 
-"message.info.readBy" = "Read by";
+"message.info.readBy" = "Seen by";
 "message.info.deliveredTo" = "Delivered to";
 "message.info.playedBy" = "Played by";
 "message.info.sent" = "Sent:";

--- a/Sources/SceytChatUIKit/ViewModels/CreateChannel/CreatePrivateChannelVM.swift
+++ b/Sources/SceytChatUIKit/ViewModels/CreateChannel/CreatePrivateChannelVM.swift
@@ -46,7 +46,7 @@ open class CreatePrivateChannelVM {
                 .create(
                     type: Config.privateChannel,
                     subject: subject,
-                    metadata: metadata,
+                    metadata: metadataObj,
                     avatarUrl: uploadedAvatarUrl?.absoluteString,
                     userIds: users.map { $0.id })
             { [weak self] channel, error in

--- a/Sources/SceytChatUIKit/Views/Channel/Profile/ChannelProfileVC.swift
+++ b/Sources/SceytChatUIKit/Views/Channel/Profile/ChannelProfileVC.swift
@@ -283,7 +283,7 @@ open class ChannelProfileVC: ViewController,
             if !profileViewModel.channel.isGroup {
                 cell.data = profileViewModel.channel.peer?.presence.status
             } else {
-                cell.data = profileViewModel.channel.decodedMetadata?.description ?? profileViewModel.channel.metadata
+                cell.data = profileViewModel.channel.decodedMetadata?.description ?? ""
             }
             _cell = cell
         case .uri:
@@ -611,12 +611,12 @@ open class ChannelProfileVC: ViewController,
         var sections: [Sections] = [.header]
         switch profileViewModel.channelType {
         case .broadcast:
-            if !(profileViewModel.channel.decodedMetadata?.description ?? profileViewModel.channel.metadata ?? "").isEmpty {
+            if !(profileViewModel.channel.decodedMetadata?.description ?? "").isEmpty {
                 sections.append(.description)
             }
             sections.append(.uri)
         case .private:
-            if !(profileViewModel.channel.decodedMetadata?.description ?? profileViewModel.channel.metadata ?? "").isEmpty {
+            if !(profileViewModel.channel.decodedMetadata?.description ?? "").isEmpty {
                 sections.append(.description)
             }
         case .direct:

--- a/Sources/SceytChatUIKit/Views/Channel/Profile/ChannelProfileVC.swift
+++ b/Sources/SceytChatUIKit/Views/Channel/Profile/ChannelProfileVC.swift
@@ -613,11 +613,15 @@ open class ChannelProfileVC: ViewController,
         case .broadcast:
             if !(profileViewModel.channel.decodedMetadata?.description ?? "").isEmpty {
                 sections.append(.description)
-            }
+            } else {
+                logger.debug("[ChannelProfileVC] decoded metadata description is missing")
+            }     
             sections.append(.uri)
         case .private:
             if !(profileViewModel.channel.decodedMetadata?.description ?? "").isEmpty {
                 sections.append(.description)
+            } else {
+                logger.debug("[ChannelProfileVC] decoded metadata description is missing")
             }
         case .direct:
             if let peer = profileViewModel.channel.peer, !peer.blocked, !(peer.presence.status ?? "").isEmpty {


### PR DESCRIPTION
Now sends metadataObj which represents JSON string, instead of plain string metadata,
Removed defaulting to the JSON string when showing data
changed read by text to Seen by